### PR TITLE
Draft 수정을 위한 포스트 리스트와 상세보기 화면 추가

### DIFF
--- a/blog/gatsby-config.js
+++ b/blog/gatsby-config.js
@@ -41,7 +41,7 @@ module.exports = {
       options: {
         apiURL: process.env.GATSBY_STRAPI_API_URL,
         token: process.env.GATSBY_STRAPI_TOKEN,
-        collectionTypes: ["Post", "Reference"],
+        collectionTypes: ["Post", "Reference", "Tag"],
       },
     },
     {

--- a/blog/gatsby-node.js
+++ b/blog/gatsby-node.js
@@ -2,11 +2,13 @@ const path = require("path");
 const { go, filter, map } = require("fxjs");
 
 exports.createPages = async ({ graphql, actions }) => {
-  const IndexPageTemplate = path.resolve(`./src/components/Index.tsx`);
+  const IndexPageTemplate = path.resolve(
+    `./src/components/Index.tsx`
+  );
   const PostDetailsTemplate = path.resolve(
     `./src/components/PostDetails/index.tsx`
   );
-  const postListTemplate = path.resolve(
+  const PostListTemplate = path.resolve(
     `./src/components/PostListTemplate.tsx`
   );
 
@@ -28,6 +30,10 @@ exports.createPages = async ({ graphql, actions }) => {
             updatedAt
             publishedAt
             slug
+            tags {
+              id
+              name
+            }
           }
         }
       }
@@ -53,7 +59,8 @@ exports.createPages = async ({ graphql, actions }) => {
   `);
 
   const releaseNode = (edge) => edge.node;
-  const filterByType = (type) => (post) => post.type === type;
+  const filterByType = (type) => (post) =>
+    post.type === type;
   const mapIndex = (node, index) => {
     return {
       index: index + 1,
@@ -78,7 +85,7 @@ exports.createPages = async ({ graphql, actions }) => {
   go(lifePosts, (posts) =>
     actions.createPage({
       path: "/life",
-      component: postListTemplate,
+      component: PostListTemplate,
       context: {
         header: "생활",
         posts,
@@ -89,7 +96,7 @@ exports.createPages = async ({ graphql, actions }) => {
   go(techPosts, (posts) =>
     actions.createPage({
       path: "/tech",
-      component: postListTemplate,
+      component: PostListTemplate,
       context: {
         header: "기술",
         posts,
@@ -100,7 +107,7 @@ exports.createPages = async ({ graphql, actions }) => {
   go(referencePosts, (references) =>
     actions.createPage({
       path: "/reference",
-      component: postListTemplate,
+      component: PostListTemplate,
       context: {
         header: "자료실",
         references,

--- a/blog/package-lock.json
+++ b/blog/package-lock.json
@@ -11,11 +11,14 @@
         "@fxts/core": "^0.19.0",
         "@gatsbyjs/reach-router": "^2.0.1",
         "@mdx-js/react": "^2.3.0",
+        "@types/fxjs": "^0.15.0",
+        "@types/qs": "^6.9.8",
         "@types/react-router": "^5.1.20",
         "@types/react-syntax-highlighter": "^15.5.7",
         "@types/recoil": "^0.0.9",
         "autoprefixer": "^10.4.4",
         "babel-plugin-styled-components": "^2.1.4",
+        "clsx": "^2.0.0",
         "fxjs": "^0.21.3",
         "gatsby": "^5.11.0",
         "gatsby-link": "^5.11.0",
@@ -35,6 +38,7 @@
         "gatsby-source-strapi-graphql": "^4.6.2",
         "gatsby-transformer-remark": "^5.25.1",
         "gatsby-transformer-sharp": "^5.11.0",
+        "qs": "^6.11.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-markdown": "^8.0.3",
@@ -5678,6 +5682,11 @@
       "resolved": "https://registry.npmjs.org/@types/extend/-/extend-3.0.1.tgz",
       "integrity": "sha512-R1g/VyKFFI2HLC1QGAeTtCBWCo6n75l41OnsVYNbmKG+kempOESaodf6BeJyUM3Q0rKa/NQcTHbB2+66lNnxLw=="
     },
+    "node_modules/@types/fxjs": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@types/fxjs/-/fxjs-0.15.0.tgz",
+      "integrity": "sha512-0DJytjz2PjgNflOpc2b6WPVpU9IDk8AucfHgMj553gi7CBGsdzhSgOy64fmcHLKqh60ZKLnq2FHMyKJStqNJxA=="
+    },
     "node_modules/@types/get-port": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@types/get-port/-/get-port-3.2.0.tgz",
@@ -5843,6 +5852,11 @@
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+    },
+    "node_modules/@types/qs": {
+      "version": "6.9.8",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.8.tgz",
+      "integrity": "sha512-u95svzDlTysU5xecFNTgfFG5RUWu1A9P0VzgpcIiGZA9iraHOdSzcxMxQ55DyeRaGCSxQi7LxXDI4rzq/MYfdg=="
     },
     "node_modules/@types/reach__router": {
       "version": "1.3.11",
@@ -7273,6 +7287,20 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
+    "node_modules/body-parser/node_modules/qs": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -8200,6 +8228,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
+      "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -10585,6 +10621,20 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/express/node_modules/qs": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/express/node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -21974,9 +22024,9 @@
       ]
     },
     "node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
+      "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
       "dependencies": {
         "side-channel": "^1.0.4"
       },
@@ -31805,6 +31855,11 @@
       "resolved": "https://registry.npmjs.org/@types/extend/-/extend-3.0.1.tgz",
       "integrity": "sha512-R1g/VyKFFI2HLC1QGAeTtCBWCo6n75l41OnsVYNbmKG+kempOESaodf6BeJyUM3Q0rKa/NQcTHbB2+66lNnxLw=="
     },
+    "@types/fxjs": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@types/fxjs/-/fxjs-0.15.0.tgz",
+      "integrity": "sha512-0DJytjz2PjgNflOpc2b6WPVpU9IDk8AucfHgMj553gi7CBGsdzhSgOy64fmcHLKqh60ZKLnq2FHMyKJStqNJxA=="
+    },
     "@types/get-port": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@types/get-port/-/get-port-3.2.0.tgz",
@@ -31970,6 +32025,11 @@
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+    },
+    "@types/qs": {
+      "version": "6.9.8",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.8.tgz",
+      "integrity": "sha512-u95svzDlTysU5xecFNTgfFG5RUWu1A9P0VzgpcIiGZA9iraHOdSzcxMxQ55DyeRaGCSxQi7LxXDI4rzq/MYfdg=="
     },
     "@types/reach__router": {
       "version": "1.3.11",
@@ -33105,6 +33165,14 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+        },
+        "qs": {
+          "version": "6.11.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+          "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
         }
       }
     },
@@ -33767,6 +33835,11 @@
       "requires": {
         "mimic-response": "^1.0.0"
       }
+    },
+    "clsx": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
+      "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q=="
     },
     "co": {
       "version": "4.6.0",
@@ -35521,6 +35594,14 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+        },
+        "qs": {
+          "version": "6.11.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+          "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
         },
         "safe-buffer": {
           "version": "5.2.1",
@@ -43623,9 +43704,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
+      "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
       "requires": {
         "side-channel": "^1.0.4"
       }

--- a/blog/package.json
+++ b/blog/package.json
@@ -23,8 +23,11 @@
     "@types/react-router": "^5.1.20",
     "@types/react-syntax-highlighter": "^15.5.7",
     "@types/recoil": "^0.0.9",
+    "@types/fxjs": "^0.15.0",
+    "@types/qs": "^6.9.8",
     "autoprefixer": "^10.4.4",
     "babel-plugin-styled-components": "^2.1.4",
+    "clsx": "^2.0.0",
     "fxjs": "^0.21.3",
     "gatsby": "^5.11.0",
     "gatsby-link": "^5.11.0",
@@ -57,7 +60,8 @@
     "sass": "^1.49.9",
     "styled-components": "^6.0.4",
     "tailwindcss": "^3.0.23",
-    "uuid": "^8.3.2"
+    "uuid": "^8.3.2",
+    "qs": "^6.11.2"
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.22.5",

--- a/blog/src/components/Layout.tsx
+++ b/blog/src/components/Layout.tsx
@@ -7,13 +7,19 @@ interface Props {
   isEditing?: boolean;
 }
 
-function Layout({ children, hasPadding = true, isEditing = false }: Props) {
+function Layout({
+  children,
+  hasPadding = true,
+  isEditing = false,
+}: Props) {
   return (
     <div className="layout-container">
       <div
         className={`contents-container glassmorph overflow-auto mx-auto ${
           isEditing ? "!w-full max-w-[1800px]" : "w-[640px]"
-        } ${hasPadding && "p-[30px] pt-[26px] flex flex-col"}`}
+        } ${
+          hasPadding && "p-[30px] pt-[26px] flex flex-col"
+        }`}
       >
         <Navigation />
         {children}

--- a/blog/src/components/ListComponents/ListItem.tsx
+++ b/blog/src/components/ListComponents/ListItem.tsx
@@ -1,15 +1,20 @@
 import React from "react";
 import { Index, Description } from "./styles";
+import { Tag } from "@src/types";
+import Tags from "./Tags";
 
 interface Props {
   index: number;
   description: string;
+  tags?: null | Array<Tag>;
 }
 
-const ListItem = ({ index, description }: Props) => {
+const ListItem = ({ index, description, tags }: Props) => {
   return (
-    <li className="cursor-pointer flex p-5 mb-3 rounded-lg glassmorph-listitem">
+    <li className="cursor-pointer flex justify-between items-center p-5 mb-3 rounded-lg glassmorph-listitem">
       <Description>{description}</Description>
+
+      {tags ? <Tags tags={tags} /> : <></>}
     </li>
   );
 };

--- a/blog/src/components/ListComponents/PostList.tsx
+++ b/blog/src/components/ListComponents/PostList.tsx
@@ -11,11 +11,14 @@ const PostList = ({ posts }: Props) => {
   return (
     <ul>
       {posts.map((post: Post) => {
+        let to = `/${post.type}/${post.slug}`;
+
+        if (!post.publishedAt) {
+          to = `/post/${post.id}`;
+        }
+
         return (
-          <Link
-            key={`key-${post.id}`}
-            to={`/${post.type}/${post.slug}`}
-          >
+          <Link key={`key-${post.id}`} to={to}>
             <ListItem
               index={post.index}
               description={post.title}

--- a/blog/src/components/ListComponents/PostList.tsx
+++ b/blog/src/components/ListComponents/PostList.tsx
@@ -19,6 +19,7 @@ const PostList = ({ posts }: Props) => {
             <ListItem
               index={post.index}
               description={post.title}
+              tags={post.tags}
             />
           </Link>
         );

--- a/blog/src/components/ListComponents/ReferenceList.tsx
+++ b/blog/src/components/ListComponents/ReferenceList.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Link } from "gatsby";
 import { Reference } from "@src/types";
 import ListItem from "./ListItem";
 
@@ -12,9 +11,12 @@ const ReferenceList = ({ references }: Props) => {
     <ul className="bg-red">
       {references.map((refer: Reference) => {
         return (
-          <Link to={refer.url} key={`key-${refer.id}`}>
-            <ListItem index={refer.index} description={refer.caption} />
-          </Link>
+          <a href={refer.url} key={`key-${refer.id}`}>
+            <ListItem
+              index={refer.index}
+              description={refer.caption}
+            />
+          </a>
         );
       })}
     </ul>

--- a/blog/src/components/ListComponents/Tags.tsx
+++ b/blog/src/components/ListComponents/Tags.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+import { Tag } from "@src/types";
+
+interface Props {
+  tags: Array<Tag>;
+}
+
+const Tags = ({ tags }: Props) => {
+  return (
+    <div className="flex items-center text-sm font-medium">
+      {tags.map((tag) => {
+        return <div key={tag.id}>{tag.name}</div>;
+      })}
+    </div>
+  );
+};
+
+export default Tags;

--- a/blog/src/components/Navigation.tsx
+++ b/blog/src/components/Navigation.tsx
@@ -1,6 +1,10 @@
 import { v4 as uuidv4 } from "uuid";
 import React, { useEffect, useState } from "react";
 import { Link } from "gatsby";
+import { useLocation } from "@reach/router";
+import clsx from "clsx";
+
+import useAuth from "@src/hooks/useAuth";
 
 export const routes = {
   tech: { title: "기술", route: "/tech" },
@@ -11,25 +15,59 @@ export const routes = {
 
 function Navigation() {
   const [navItems, setNavItems] = useState<
-    Array<{ id: null | string; title: string; route: string }>
-  >(Object.values(routes).map((route) => ({ id: null, ...route })));
+    Array<{
+      id: null | string;
+      title: string;
+      route: string;
+    }>
+  >(
+    Object.values(routes).map((route) => ({
+      id: null,
+      ...route,
+    }))
+  );
 
   useEffect(() => {
-    setNavItems(navItems.map((el) => ({ ...el, id: uuidv4() })));
+    setNavItems(
+      navItems.map((el) => ({ ...el, id: uuidv4() }))
+    );
   }, []);
+
+  const { isAuthorized } = useAuth();
+  const { pathname } = useLocation();
 
   return (
     <div className="nav w-full mb-2">
       <ul className="flex pb-3">
         {navItems.map((el, index) => {
           return (
-            <Link className="underline mr-3" key={el.id ?? index} to={el.route}>
+            <Link
+              className={clsx(
+                "mr-3",
+                pathname.includes(el.route) && "underline"
+              )}
+              key={el.id ?? index}
+              to={el.route}
+            >
               <li className="cursor-pointer">{el.title}</li>
             </Link>
           );
         })}
+
+        {isAuthorized && (
+          <Link
+            className={clsx(
+              "mr-3",
+              pathname.includes("/posts") && "underline"
+            )}
+            to={"/posts"}
+          >
+            <li className="cursor-pointer">포스트</li>
+          </Link>
+        )}
+
         <Link
-          className="underline ml-auto font-[500] whitespace-nowrap"
+          className="ml-auto font-[500] whitespace-nowrap"
           to="/about"
         >
           <li>저스틴 블로그</li>

--- a/blog/src/components/PostDetails/ContentsEditor.tsx
+++ b/blog/src/components/PostDetails/ContentsEditor.tsx
@@ -18,10 +18,8 @@ const POST_TYPES: Record<string, string> = {
 
 interface Props {
   title: string;
-  editingContents: string;
-  onChangeTitle?: (
-    e: ChangeEvent<HTMLInputElement>
-  ) => void;
+  contents: string;
+  onChangeTitle: (e: ChangeEvent<HTMLInputElement>) => void;
   onChangeContents: (
     e: ChangeEvent<HTMLTextAreaElement>
   ) => void;
@@ -30,7 +28,7 @@ interface Props {
 
 const ContentsEditor = ({
   title,
-  editingContents,
+  contents,
   onChangeContents,
   onChangeTitle,
   buttons,
@@ -85,7 +83,7 @@ const ContentsEditor = ({
 
       <textarea
         className={`w-full flex-1 bg-white text-blue-500 mt-5 p-3`}
-        value={editingContents}
+        value={contents}
         onChange={onChangeContents}
         onKeyUp={(
           e: KeyboardEvent<HTMLTextAreaElement>

--- a/blog/src/hooks/useAuth.ts
+++ b/blog/src/hooks/useAuth.ts
@@ -1,10 +1,16 @@
 import axios from "axios";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
+import { atom, useRecoilState } from "recoil";
+
+const isAuthorizedState = atom<boolean | null>({
+  key: "IsAuthorizedState",
+  default: null,
+});
 
 const useAuth = () => {
-  const [isAuthorized, setIsAuthorized] = useState<
-    boolean | null
-  >(null);
+  const [isAuthorized, setIsAuthorized] = useRecoilState(
+    isAuthorizedState
+  );
 
   useEffect(() => {
     const token = localStorage.getItem("justinblog-token");
@@ -20,7 +26,7 @@ const useAuth = () => {
         await axios.post(
           `${process.env.GATSBY_STRAPI_API_URL}/api/users-permissions/token/decrypt`,
           {
-            token: token,
+            token,
           }
         );
 

--- a/blog/src/pages/editor.tsx
+++ b/blog/src/pages/editor.tsx
@@ -1,24 +1,20 @@
 import axios from "axios";
-import React, {
-  ChangeEvent,
-  MouseEvent,
-  useState,
-} from "react";
+import React, { MouseEvent } from "react";
 
-import Layout from "@components/Layout";
-import ContentsEditor from "@components/PostDetails/ContentsEditor";
-import ContentsViewer from "@components/PostDetails/ContentsViewer";
-import Authorizer from "@components/Authorizer";
-import { Container } from "@components/PostDetails";
+import PostDetails, {
+  editingContentsState,
+  editingTitleState,
+} from "@components/PostDetails";
 import usePostType from "@src/hooks/usePostType";
+import { useRecoilValue } from "recoil";
 
 const EditorPage = () => {
   const isBrowser = typeof window !== "undefined";
 
   if (!isBrowser) return <></>;
 
-  const [title, setTitle] = useState("");
-  const [contents, setContents] = useState("");
+  const title = useRecoilValue(editingTitleState);
+  const contents = useRecoilValue(editingContentsState);
 
   const { selectedPostType } = usePostType();
 
@@ -70,46 +66,34 @@ const EditorPage = () => {
     await savePost("publish");
   };
 
+  const buttons = (
+    <div className="flex">
+      <button
+        onClick={handleSaveButtonClick}
+        className="flex-1 p-5 bg-orange-300"
+      >
+        저장하기
+      </button>
+
+      <button
+        onClick={handleRegisterButtonClick}
+        className="flex-1 p-5 bg-green-300"
+      >
+        작성하기
+      </button>
+    </div>
+  );
+
   return (
-    <Authorizer>
-      <Layout isEditing={true}>
-        <Container>
-          <ContentsEditor
-            title={title}
-            editingContents={contents}
-            onChangeContents={(
-              e: ChangeEvent<HTMLTextAreaElement>
-            ) => setContents(e.currentTarget.value)}
-            onChangeTitle={(
-              e: ChangeEvent<HTMLInputElement>
-            ) => setTitle(e.target.value)}
-            buttons={
-              <div className="flex">
-                <button
-                  onClick={handleSaveButtonClick}
-                  className="flex-1 p-5 bg-orange-300"
-                >
-                  저장하기
-                </button>
-
-                <button
-                  onClick={handleRegisterButtonClick}
-                  className="flex-1 p-5 bg-green-300"
-                >
-                  작성하기
-                </button>
-              </div>
-            }
-          />
-
-          <ContentsViewer
-            isEditable={true}
-            title={title}
-            contents={contents}
-          />
-        </Container>
-      </Layout>
-    </Authorizer>
+    <PostDetails
+      pageContext={{
+        post: {
+          title,
+          contents,
+        },
+      }}
+      buttons={buttons}
+    />
   );
 };
 

--- a/blog/src/pages/post/[postId].tsx
+++ b/blog/src/pages/post/[postId].tsx
@@ -1,0 +1,105 @@
+import axios from "axios";
+import React from "react";
+
+import { Post } from "@src/types";
+import PostDetails, {
+  editingContentsState,
+  editingTitleState,
+} from "@components/PostDetails";
+import { useRecoilValue } from "recoil";
+
+interface Props {
+  serverData: {
+    post: Post;
+  };
+}
+
+const PostPage = ({ serverData: { post } }: Props) => {
+  const title = useRecoilValue(editingTitleState);
+  const contents = useRecoilValue(editingContentsState);
+
+  const publishPost = async () => {
+    try {
+      const token = localStorage.getItem(
+        "justinblog-token"
+      );
+
+      console.log({
+        title,
+        contents,
+        publishedAt: new Date(),
+      });
+
+      const response = await axios.put(
+        `${process.env.GATSBY_STRAPI_API_URL}/api/posts/${post.id}`,
+        {
+          data: {
+            title,
+            contents,
+            publishedAt: new Date(),
+          },
+        },
+        {
+          headers: {
+            Authorization: `bearer ${token}`,
+          },
+        }
+      );
+
+      alert("수정 성공!");
+
+      location.href = "/";
+    } catch (error) {
+      console.log("변경중 에러 발생");
+      console.log(error);
+    }
+  };
+
+  const publishButton = (
+    <button
+      onClick={async () => {
+        await publishPost();
+      }}
+      className="p-5 bg-pink-400"
+    >
+      공개하기
+    </button>
+  );
+
+  return (
+    <PostDetails
+      pageContext={{
+        post,
+      }}
+      buttons={publishButton}
+    />
+  );
+};
+
+export default PostPage;
+
+export async function getServerData(ctx: {
+  params: Record<string, string>;
+}) {
+  const { postId } = ctx.params;
+
+  const {
+    data: { data },
+  } = await axios(
+    `${process.env.GATSBY_STRAPI_API_URL}/api/posts/${postId}`,
+    {
+      headers: {
+        authorization: `Bearer ${process.env.GATSBY_STRAPI_TOKEN}`,
+      },
+    }
+  );
+
+  return {
+    props: {
+      post: {
+        id: postId,
+        ...data.attributes,
+      },
+    },
+  };
+}

--- a/blog/src/pages/posts.tsx
+++ b/blog/src/pages/posts.tsx
@@ -1,0 +1,173 @@
+import React from "react";
+import axios from "axios";
+import qs from "qs";
+import { map, pipe, take, toArray } from "@fxts/core";
+import styled from "styled-components";
+import clsx from "clsx";
+import { useLocation } from "@reach/router";
+
+import { Post } from "@src/types";
+import Authorizer from "@components/Authorizer";
+import Layout from "@components/Layout";
+import PostList from "@components/ListComponents/PostList";
+
+interface Props {
+  serverData: {
+    posts: Array<Post>;
+    totalPages: number;
+    currentPage: number;
+  };
+}
+
+const PostListPage = ({
+  serverData: { posts, totalPages, currentPage },
+}: Props) => {
+  const { search, href, pathname } = useLocation();
+
+  const parsedQuery = qs.parse(search.split("?")[1]);
+
+  const { publicationState } = parsedQuery;
+
+  const pages = pipe(
+    (function* generatePage() {
+      let i = 0;
+      while (++i) yield i;
+    })(),
+    take(totalPages),
+    map((page) => (
+      <a
+        href={`${pathname}?${qs.stringify(
+          { ...parsedQuery, page },
+          { encode: false }
+        )}`}
+        key={`page-${page}`}
+      >
+        <span
+          className={clsx(
+            "p-1",
+            page === currentPage && "underline"
+          )}
+        >
+          {page}
+        </span>
+      </a>
+    )),
+    toArray
+  );
+
+  return (
+    <Authorizer>
+      <Layout>
+        <Filters>
+          <a href="/posts?publicationState=draft">
+            <li
+              className={clsx(
+                publicationState === "draft" && "underline"
+              )}
+            >
+              Draft
+            </li>
+          </a>
+
+          <a href="/posts?publicationState=published">
+            <li
+              className={clsx(
+                publicationState === "published" &&
+                  "underline"
+              )}
+            >
+              Published
+            </li>
+          </a>
+
+          <li className="ml-auto !mr-0">{pages}</li>
+        </Filters>
+        <PostList posts={posts} />
+      </Layout>
+    </Authorizer>
+  );
+};
+
+export default PostListPage;
+
+export async function getServerData(ctx: {
+  headers: Map<string, string>;
+}) {
+  const href = ctx.headers.get("referer") as string;
+  const queried = qs.parse(href.split("?")[1]);
+
+  const filters = {};
+
+  const publicationState =
+    queried["publicationState"] === "published"
+      ? "live"
+      : "preview";
+
+  if (queried["publicationState"] === "draft") {
+    Object.assign(filters, {
+      publishedAt: { $null: true },
+    });
+  }
+
+  const query = qs.stringify(
+    {
+      sort: "createdAt:desc",
+      publicationState,
+      filters,
+      pagination: {
+        page: queried.page ? Number(queried.page) : 1,
+        pageSize: 10,
+      },
+    },
+    { encode: false }
+  );
+
+  const {
+    data: { data, meta },
+  }: {
+    data: {
+      data: Array<{
+        id: number;
+        attributes: Omit<Post, "id">;
+      }>;
+      meta: {
+        pagination: {
+          page: number;
+          pageSize: number;
+          pageCount: number;
+          total: number;
+        };
+      };
+    };
+  } = await axios(
+    `${process.env.GATSBY_STRAPI_API_URL}/api/posts?${query}`,
+    {
+      headers: {
+        authorization: `Bearer ${process.env.GATSBY_STRAPI_TOKEN}`,
+      },
+    }
+  );
+
+  const posts = pipe(
+    data,
+    map(({ id, attributes }) => ({ id, ...attributes })),
+    toArray
+  );
+
+  return {
+    props: {
+      posts,
+      totalPages: meta.pagination.pageCount,
+      currentPage: meta.pagination.page,
+    },
+  };
+}
+
+const Filters = styled.ul`
+  display: flex;
+  margin-bottom: 1em;
+
+  & li {
+    margin-right: 1em;
+  }
+`;

--- a/blog/src/types/index.ts
+++ b/blog/src/types/index.ts
@@ -6,6 +6,11 @@ export interface PostQueryResult {
   };
 }
 
+export interface Tag {
+  id: string;
+  name: string;
+}
+
 export interface Post {
   index: number;
   id: number;
@@ -17,6 +22,7 @@ export interface Post {
   updatedAt: string;
   publishedAt: string;
   slug: string;
+  tags: null | Array<Tag>;
 }
 
 export interface Reference {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,12 @@
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.0.4",
         "@types/fxjs": "^0.15.0",
+        "@types/qs": "^6.9.8",
+        "clsx": "^2.0.0",
         "fxjs": "^0.21.3",
         "http-errors": "^2.0.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.21",
+        "qs": "^6.11.2"
       }
     },
     "node_modules/@babel/runtime": {
@@ -400,6 +403,11 @@
       "resolved": "https://registry.npmjs.org/@types/fxjs/-/fxjs-0.15.0.tgz",
       "integrity": "sha512-0DJytjz2PjgNflOpc2b6WPVpU9IDk8AucfHgMj553gi7CBGsdzhSgOy64fmcHLKqh60ZKLnq2FHMyKJStqNJxA=="
     },
+    "node_modules/@types/qs": {
+      "version": "6.9.8",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.8.tgz",
+      "integrity": "sha512-u95svzDlTysU5xecFNTgfFG5RUWu1A9P0VzgpcIiGZA9iraHOdSzcxMxQ55DyeRaGCSxQi7LxXDI4rzq/MYfdg=="
+    },
     "node_modules/aria-hidden": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.3.tgz",
@@ -409,6 +417,26 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
+      "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/core-js-pure": {
@@ -434,6 +462,11 @@
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
     "node_modules/fxjs": {
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/fxjs/-/fxjs-0.21.3.tgz",
@@ -442,12 +475,59 @@
         "@babel/runtime-corejs3": "^7.14.5"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-proto": "^1.0.1",
+        "has-symbols": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-nonce": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
       "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/http-errors": {
@@ -497,6 +577,28 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
+      "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/react": {
@@ -609,6 +711,19 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "node_modules/side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/statuses": {
       "version": "2.0.1",
@@ -875,6 +990,11 @@
       "resolved": "https://registry.npmjs.org/@types/fxjs/-/fxjs-0.15.0.tgz",
       "integrity": "sha512-0DJytjz2PjgNflOpc2b6WPVpU9IDk8AucfHgMj553gi7CBGsdzhSgOy64fmcHLKqh60ZKLnq2FHMyKJStqNJxA=="
     },
+    "@types/qs": {
+      "version": "6.9.8",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.8.tgz",
+      "integrity": "sha512-u95svzDlTysU5xecFNTgfFG5RUWu1A9P0VzgpcIiGZA9iraHOdSzcxMxQ55DyeRaGCSxQi7LxXDI4rzq/MYfdg=="
+    },
     "aria-hidden": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.3.tgz",
@@ -882,6 +1002,20 @@
       "requires": {
         "tslib": "^2.0.0"
       }
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
+    "clsx": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
+      "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q=="
     },
     "core-js-pure": {
       "version": "3.31.1",
@@ -898,6 +1032,11 @@
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
     "fxjs": {
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/fxjs/-/fxjs-0.21.3.tgz",
@@ -906,10 +1045,39 @@
         "@babel/runtime-corejs3": "^7.14.5"
       }
     },
+    "get-intrinsic": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-proto": "^1.0.1",
+        "has-symbols": "^1.0.3"
+      }
+    },
     "get-nonce": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
       "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg=="
+    },
+    "has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
     },
     "http-errors": {
       "version": "2.0.0",
@@ -952,6 +1120,19 @@
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "object-inspect": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g=="
+    },
+    "qs": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
+      "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
+      "requires": {
+        "side-channel": "^1.0.4"
       }
     },
     "react": {
@@ -1022,6 +1203,16 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      }
     },
     "statuses": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,11 @@
   "dependencies": {
     "@radix-ui/react-alert-dialog": "^1.0.4",
     "@types/fxjs": "^0.15.0",
+    "@types/qs": "^6.9.8",
+    "clsx": "^2.0.0",
     "fxjs": "^0.21.3",
     "http-errors": "^2.0.0",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "qs": "^6.11.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,12 +10,8 @@
   "license": "ISC",
   "dependencies": {
     "@radix-ui/react-alert-dialog": "^1.0.4",
-    "@types/fxjs": "^0.15.0",
-    "@types/qs": "^6.9.8",
-    "clsx": "^2.0.0",
     "fxjs": "^0.21.3",
     "http-errors": "^2.0.0",
-    "lodash": "^4.17.21",
-    "qs": "^6.11.2"
+    "lodash": "^4.17.21"
   }
 }


### PR DESCRIPTION
draft 포스트 수정을 위한 포스트 리스트와 에디팅 화면을 개발했습니다.
draft 포스트는 빌드과정에서 생성되는 페이지에 포함되지 않으므로 SSR로 렌더링됩니다.

<img src="https://github.com/nninnnin/justindglee.com/assets/34882520/8926640b-7365-4c96-954b-96ffe16244d1" width="50%" />

그리고 포스트를 에디팅하는 3개의 페이지

- `/editor` : 새로운 글을 작성하기 위한 페이지
- `/<post-type>/<post-slug>?edit=1` : 퍼블리싱 되어있는 글을 수정하기 위한 페이지
- `/post/[postId]?edit=1` : 퍼블리싱 되어있지 않은 초안을 수정하기 위한 페이지

에서 동일한 `PostDetails` 컴포넌트를 사용하도록 개선하여 중복된 로직을 최소화 하였습니다.

각각의 상황에서 유일하게 다른 부분은 글을 작성 또는 수정 후에 마지막으로 눌리는 버튼들인데,

<div>
  <img src="https://github.com/nninnnin/justindglee.com/assets/34882520/7ac406a0-67f9-43e0-bbf8-864c9b8f1a0c" width="33%" style="display: inline;" />
  <img src="https://github.com/nninnnin/justindglee.com/assets/34882520/14c67959-0162-4cf3-9e4a-95fa420a062c" width="33%" style="display: inline;" />
  <img src="https://github.com/nninnnin/justindglee.com/assets/34882520/bba91560-7d19-4ee0-b65d-9a4d0001c750" width="33%" style="display: inline;" />
</div>

<br/>

이들 버튼을 인터페이스를 통해 주입시켜 3가지 상황에서 모두 유연하게 사용될 수 있도록 구현했습니다.